### PR TITLE
Change extension documentation from hggit to hg-git

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,7 +124,7 @@ $ hg push</pre>
         </p>
         <pre>[extensions]
 hgext.bookmarks =
-hggit = </pre>
+hg-git = </pre>
         <p>
           ...and that's it! 
         </p>
@@ -150,7 +150,7 @@ hggit = </pre>
 
         <pre>[extensions]
 hgext.bookmarks =
-hggit = [path-to]/hg-git/hggit</pre>
+hg-git = [path-to]/hg-git/hggit</pre>
 
         <p>
           That will enable the Hg-Git extension for you. The bookmarks


### PR DESCRIPTION
The extensions that comes with TortoiseHG is named `hg-git`, with the '-', and not, as previously described, `hggit`.
